### PR TITLE
Adding Pool / Pool::Object design pattern

### DIFF
--- a/includes/design_pattern/spk_pool.hpp
+++ b/includes/design_pattern/spk_pool.hpp
@@ -2,30 +2,30 @@
 
 namespace spk
 {
-    template<typename TType>
-	class Pool
-	{	
-	private:
-        using Container = std::vector<TType*>;
+    template <typename TType>
+    class Pool
+    {
+    private:
+        using Container = std::vector<TType *>;
         Container _allocatedObjects;
 
-	public:
-		class Object
-		{
+    public:
+        class Object
+        {
             friend class Pool;
-		private:
-            Container* _source;
-            size_t *_referenceCount;
-            TType* _content;
-	
-			Object(Container* p_source, TType* p_content) :
-                _source(p_source),
-                _content(p_content),
-                _referenceCount(new size_t(1))
-            {
 
+        private:
+            Container *_source;
+            size_t *_referenceCount;
+            TType *_content;
+
+            Object(Container *p_source, TType *p_content) : _source(p_source),
+                                                            _content(p_content),
+                                                            _referenceCount(new size_t(1))
+            {
             }
-		public:
+
+        public:
             ~Object()
             {
                 (*_referenceCount)--;
@@ -34,51 +34,49 @@ namespace spk
                     _source->push_back(_content);
             }
 
-            Object(const Object& p_other) :
-                _source(p_other._source),
-                _content(p_other._content),
-                _referenceCount(p_other._referenceCount)
+            Object(const Object &p_other) : _source(p_other._source),
+                                            _content(p_other._content),
+                                            _referenceCount(p_other._referenceCount)
             {
                 (*_referenceCount)++;
             }
 
-			TType* operator()()
+            TType *operator()()
             {
                 return (_content);
             }
-			const TType* operator()() const 
+            const TType *operator()() const
             {
                 return (_content);
             }
-            
-            TType* operator->()
+
+            TType *operator->()
             {
                 return (_content);
             }
-			const TType* operator->() const 
+            const TType *operator->() const
             {
                 return (_content);
             }
-            
-            TType& operator*()
+
+            TType &operator*()
             {
                 return *_content;
             }
 
-            const TType& operator*() const
+            const TType &operator*() const
             {
                 return *_content;
             }
-		};
-        
-	public:
-		Pool()
+        };
+
+    public:
+        Pool()
         {
-
         }
-	
-		template <typename ... Args>
-		void reserve(size_t p_nbElement, Args&&... p_args)
+
+        template <typename... Args>
+        void reserve(size_t p_nbElement, Args &&...p_args)
         {
             size_t currentSize = _allocatedObjects.size();
 
@@ -88,9 +86,9 @@ namespace spk
                 _allocatedObjects[i] = new TType(std::forward<Args>(p_args)...);
             }
         }
-	
-		template <typename ... Args>
-		Object obtain(Args&&... p_args)
+
+        template <typename... Args>
+        Object obtain(Args &&...p_args)
         {
             if (_allocatedObjects.size() == 0)
             {
@@ -100,22 +98,19 @@ namespace spk
             }
             else
             {
-                TType* data = _allocatedObjects.back();
+                TType *data = _allocatedObjects.back();
                 _allocatedObjects.pop_back();
 
                 *data = TType(std::forward<Args>(p_args)...);
 
                 Object result = Object(&_allocatedObjects, data);
-                return (result);    
+                return (result);
             }
-
-            
         }
-	
-		size_t size() const
+
+        size_t size() const
         {
             return (_allocatedObjects.size());
         }
-	};
-
+    };
 }

--- a/includes/design_pattern/spk_pool.hpp
+++ b/includes/design_pattern/spk_pool.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#define DEBUG_LINE() std::cout << __FUNCTION__ << "::" << __LINE__ << std::endl
+
 namespace spk
 {
     template<typename TType>

--- a/includes/design_pattern/spk_pool.hpp
+++ b/includes/design_pattern/spk_pool.hpp
@@ -1,0 +1,121 @@
+#pragma once
+#define DEBUG_LINE() std::cout << __FUNCTION__ << "::" << __LINE__ << std::endl
+namespace spk
+{
+    template<typename TType>
+	class Pool
+	{	
+	private:
+        using Container = std::vector<TType*>;
+        Container _allocatedObjects;
+
+	public:
+		class Object
+		{
+            friend class Pool;
+		private:
+            Container* _source;
+            size_t *_referenceCount;
+            TType* _content;
+	
+			Object(Container* p_source, TType* p_content) :
+                _source(p_source),
+                _content(p_content),
+                _referenceCount(new size_t(1))
+            {
+
+            }
+		public:
+            ~Object()
+            {
+                (*_referenceCount)--;
+
+                if (*_referenceCount == 0)
+                    _source->push_back(_content);
+            }
+
+            Object(const Object& p_other) :
+                _source(p_other._source),
+                _content(p_other._content),
+                _referenceCount(p_other._referenceCount)
+            {
+                (*_referenceCount)++;
+            }
+
+			TType* operator()()
+            {
+                return (_content);
+            }
+			const TType* operator()() const 
+            {
+                return (_content);
+            }
+            
+            TType* operator->()
+            {
+                return (_content);
+            }
+			const TType* operator->() const 
+            {
+                return (_content);
+            }
+            
+            TType& operator*()
+            {
+                return *_content;
+            }
+
+            const TType& operator*() const
+            {
+                return *_content;
+            }
+		};
+        
+	public:
+		Pool()
+        {
+
+        }
+	
+		template <typename ... Args>
+		void reserve(size_t p_nbElement, Args&&... p_args)
+        {
+            size_t currentSize = _allocatedObjects.size();
+
+            _allocatedObjects.resize(currentSize + p_nbElement);
+            for (size_t i = currentSize; i < p_nbElement; i++)
+            {
+                _allocatedObjects[i] = new TType(std::forward<Args>(p_args)...);
+            }
+        }
+	
+		template <typename ... Args>
+		Object obtain(Args&&... p_args)
+        {
+            if (_allocatedObjects.size() == 0)
+            {
+                Object result = Object(&_allocatedObjects, new TType(std::forward<Args>(p_args)...));
+
+                return (result);
+            }
+            else
+            {
+                TType* data = _allocatedObjects.back();
+                _allocatedObjects.pop_back();
+
+                *data = TType(std::forward<Args>(p_args)...);
+
+                Object result = Object(&_allocatedObjects, data);
+                return (result);    
+            }
+
+            
+        }
+	
+		size_t size() const
+        {
+            return (_allocatedObjects.size());
+        }
+	};
+
+}

--- a/includes/sparkle.hpp
+++ b/includes/sparkle.hpp
@@ -9,3 +9,4 @@
 #include "data_structure/spk_data_buffer.hpp"
 #include "design_pattern/spk_stated_object.hpp"
 #include "design_pattern/spk_activable_object.hpp"
+#include "design_pattern/spk_pool.hpp"

--- a/playground/includes/playground.hpp
+++ b/playground/includes/playground.hpp
@@ -1,1 +1,3 @@
 #include "sparkle.hpp"
+
+#define DEBUG_LINE() std::cout << __FUNCTION__ << "::" << __LINE__ << std::endl

--- a/playground/includes/playground.hpp
+++ b/playground/includes/playground.hpp
@@ -1,3 +1,1 @@
 #include "sparkle.hpp"
-
-#define DEBUG_LINE() std::cout << __FUNCTION__ << "::" << __LINE__ << std::endl

--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -1,52 +1,34 @@
 #include "playground.hpp"
 
-void activeCallback() {
-    std::cout << "The object is active." << std::endl;
+spk::Pool<int> pool;
+
+void initiatePool()
+{
+    pool.reserve(10, 5);
 }
 
-void inactiveCallback() {
-    std::cout << "The object is inactive." << std::endl;
+
+spk::Pool<int>::Object functA()
+{
+    std::cout << "Initial size : " << pool.size() << std::endl;
+    spk::Pool<int>::Object valueA = pool.obtain(10);
+    spk::Pool<int>::Object valueB = pool.obtain(5);
+    spk::Pool<int>::Object result = pool.obtain(*valueA + *valueB);
+
+    std::cout << "After obtain size : " << pool.size() << std::endl;
+
+    std::cout << "Operation : " << *valueA << " + " << *valueB << " = " << *result << std::endl;
+    std::cout << "At end of function : " << pool.size() << std::endl;
+
+    return (result);
 }
 
-int main() {
-    // Création d'un ActivableObject
-    spk::ActivableObject activable;
+int main()
+{
+    initiatePool();
 
-    // Ajout de callbacks pour les états actif et inactif
-    auto activeContract = activable.addActivationCallback(activeCallback);
-    auto inactiveContract = activable.addDeactivationCallback(inactiveCallback);
+    spk::Pool<int>::Object sum = functA();
 
-    // Activation de l'objet, déclenche le callback actif
-    activable.activate();
-
-    // Vérification de l'état de l'objet
-    std::cout << "Is active: " << (activable.isActive() ? "true" : "false") << std::endl;
-
-    // Désactivation de l'objet, déclenche le callback inactif
-    activable.deactivate();
-
-    // Vérification de l'état de l'objet
-    std::cout << "Is active: " << (activable.isActive() ? "true" : "false") << std::endl;
-
-    // Tentative de modification d'un contrat (doit échouer)
-    try {
-        activeContract.edit([]() { std::cout << "Modified callback." << std::endl; });
-    } catch (const std::runtime_error &e) {
-        std::cout << "Error: " << e.what() << std::endl;
-    }
-
-    // Démission d'un contrat
-    activeContract.resign();
-
-    // Activation de l'objet, ne devrait pas déclencher le callback actif
-    activable.activate();
-
-    // Tentative de démission d'un contrat déjà démissionné (doit échouer)
-    try {
-        activeContract.resign();
-    } catch (const std::runtime_error &e) {
-        std::cout << "Error: " << e.what() << std::endl;
-    }
-
+    std::cout << "Outside of function : " << pool.size() << std::endl;
     return 0;
 }

--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -7,7 +7,6 @@ void initiatePool()
     pool.reserve(10, 5);
 }
 
-
 spk::Pool<int>::Object functA()
 {
     std::cout << "Initial size : " << pool.size() << std::endl;


### PR DESCRIPTION
Adding two structures : 
- Pool : Holding pre-instancied object, with a method obtain to pull one apart
- Pool::Object : Hold one instance of a pre-instancied object. Work as same as the std::shared_ptr but return the memory into Pool instead of releasing it