### PR TITLE
The Thread::_starterSignal become a promise<void>

### DIFF
--- a/includes/threading/spk_thread.hpp
+++ b/includes/threading/spk_thread.hpp
@@ -21,7 +21,7 @@ namespace spk
     private:
         std::function<void()> _funct;
         std::thread _thread;
-        std::promise<bool> _starterSignal;
+        std::promise<void> _starterSignal;
 
     public:
         template <typename Funct, typename... Args>

--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -1,35 +1,14 @@
 #include "playground.hpp"
 
-spk::Promise<int> promise;
-
-void callback()
-{
-	spk::cout << "Callback called" << std::endl;
-}
-
-void promiseTests()
-{
-	std::this_thread::sleep_for(std::chrono::seconds(1));
-	promise.setValue(42);
-	try
-	{
-		promise.setValue(42);
-	}
-	catch (const std::exception& e)
-	{
-		std::cerr << e.what() << '\n';
-	}
-}
 
 int main()
 {
-	auto contract = promise.subscribe(callback);
-	auto second_contract = promise.subscribe([]() { spk::cout << L"Second callback called" << std::endl; });
+	spk::Thread thread(spk::Thread::LaunchMethod::Delayed, L"Thread", []()
+	{
+		spk::cout << L"Hello world!" << std::endl;
+	});
+	thread.start();
+	thread.join();
 
-	spk::Thread thread(spk::Thread::LaunchMethod::Immediate, L"Promise test", promiseTests);
-	contract.resign();
-
-	spk::cout << L"Promise value: " << promise.value() << std::endl;
-	spk::cout << L"Promise value: " << promise.value() << std::endl;
 	return 0;
 }

--- a/src/threading/spk_thread.cpp
+++ b/src/threading/spk_thread.cpp
@@ -17,7 +17,7 @@ namespace spk
     {
         try
         {
-            _starterSignal.set_value(true);
+            _starterSignal.set_value();
         }
         catch(const std::exception& e)
         {


### PR DESCRIPTION
It was possible to use the Promise void specialization to start the Thread instead of a bool.